### PR TITLE
fix(#67): provide abilitiy to separate comments from block highlights

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1308,6 +1308,7 @@ export default class MyPlugin extends Plugin {
 			}
 
 			//FORMAT HIGHLIGHTED SENTENCES WITHOUT ANY COMMENT
+			//OR WITHOUT ANY SPECIAL CONSIDERATIONS
 			if (lineElements.annotationType === "noKey") {
 				console.log("lineElements.annotationType === noKey")
 				if (lineElements.highlightText !== "") {
@@ -1323,6 +1324,7 @@ export default class MyPlugin extends Plugin {
 					if (lineElements.commentText !== "") {
 						lineElements.rowEdited =
 							lineElements.rowEdited +
+							commentPrepend +
 							commentFormatBefore +
 							lineElements.commentText +
 							commentFormatAfter;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -418,7 +418,7 @@ export class SettingTab extends PluginSettingTab {
 
 			new Setting(settingsHighlights)
 				.setName("Custom text before all highlights")
-				.addText((text) =>
+				.addTextArea((text) =>
 					text
 						.setValue(settings.highlightCustomTextBefore)
 						.onChange(async (value) => {
@@ -430,7 +430,7 @@ export class SettingTab extends PluginSettingTab {
 
 			new Setting(settingsHighlights)
 				.setName("Custom text after all highlights")
-				.addText((text) =>
+				.addTextArea((text) =>
 					text
 						.setValue(settings.highlightCustomTextAfter)
 						.onChange(async (value) => {
@@ -515,7 +515,7 @@ export class SettingTab extends PluginSettingTab {
 
 			new Setting(settingsComments)
 				.setName("Custom text before all comments")
-				.addText((text) =>
+				.addTextArea((text) =>
 					text
 						.setValue(settings.commentCustomTextBefore)
 						.onChange(async (value) => {
@@ -527,7 +527,7 @@ export class SettingTab extends PluginSettingTab {
 
 			new Setting(settingsComments)
 				.setName("Custom text after all comments")
-				.addText((text) =>
+				.addTextArea((text) =>
 					text
 						.setValue(settings.commentCustomTextAfter)
 						.onChange(async (value) => {


### PR DESCRIPTION
Atm if you choose "comments after highlights" and make the highlights blockquote (to mimic how they look in Zotero) the highlight will look like this (the selected part is the comment):
<img width="642" alt="image" src="https://user-images.githubusercontent.com/21983833/163431322-af115d63-7e51-42e0-bf25-44709509b821.png">


This pr 
1. Changes the "prepend" text fields from simple strings to textareas
2. Actually adds the prepend-text to the comment when it is a "comment after highlight" comment (annotationType === 'noKey', but with text).

This allows you to add two newlines before the comment, which makes it look like this:
<img width="642" alt="image" src="https://user-images.githubusercontent.com/21983833/163430930-a060d36f-ac65-4482-b80d-cdac061f19ac.png">
